### PR TITLE
Fix userVerificationError remediation

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,5 +14,5 @@ repositories {
 
 dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.8.0")
-    implementation("org.owasp:dependency-check-gradle:7.3.0")
+    implementation("org.owasp:dependency-check-gradle:7.3.2")
 }

--- a/buildSrc/src/main/java/Version.kt
+++ b/buildSrc/src/main/java/Version.kt
@@ -2,16 +2,16 @@
  * Version variables
  */
 object Version {
-    const val kotlin = "1.7.20"
-    const val kotlinSerialization = "1.4.0"
+    const val kotlin = "1.7.21"
+    const val kotlinSerialization = "1.4.1"
     const val coroutine = "1.6.4"
     const val room = "2.4.3"
     const val extJunit = "1.1.3"
     const val archLifecycleVersion = "2.5.1"
-    const val compose = "1.3.0-rc01"
-    const val composeCompiler = "1.3.2"
-    const val devicesAuthenticator = "0.0.2-SNAPSHOT"
-    const val devicesCore = "0.0.2-SNAPSHOT"
-    const val devicesStorage = "0.0.2-SNAPSHOT"
-    const val devicesFakeServer = "0.0.2-SNAPSHOT"
+    const val compose = "1.4.0-alpha02"
+    const val composeCompiler = "1.4.0-alpha02"
+    const val devicesAuthenticator = "0.0.2"
+    const val devicesCore = "0.0.2"
+    const val devicesStorage = "0.0.2"
+    const val devicesFakeServer = "0.0.2"
 }

--- a/config/owasp-suppression.xml
+++ b/config/owasp-suppression.xml
@@ -14,5 +14,12 @@
         <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf\-javalite@.*$</packageUrl>
         <cve>CVE-2022-3171</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: kotlinx-coroutines-play-services-1.6.4.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlinx/kotlinx\-coroutines\-play\-services@.*$</packageUrl>
+        <cve>CVE-2022-39349</cve>
+    </suppress>
 </suppressions>
 

--- a/devices-push/build.gradle.kts
+++ b/devices-push/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-basement:18.1.0")
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
 
+    testImplementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
     testImplementation("com.okta.devices:devices-fake-server:${Version.devicesFakeServer}")
     testImplementation("androidx.arch.core:core-testing:2.1.0")
     testImplementation("androidx.room:room-testing:${Version.room}")

--- a/devices-push/src/test/java/com/okta/devices/push/utils/BaseTest.kt
+++ b/devices-push/src/test/java/com/okta/devices/push/utils/BaseTest.kt
@@ -14,8 +14,8 @@
  */
 package com.okta.devices.push.utils
 
+import android.os.Build
 import androidx.annotation.CallSuper
-import com.okta.devices.fake.util.isRobolectric
 import io.mockk.MockKAnnotations
 import io.mockk.unmockkAll
 import org.junit.After
@@ -32,6 +32,7 @@ open class BaseTest {
     }
 
     companion object {
+        fun isRobolectric() = "robolectric" == Build.FINGERPRINT
 
         @BeforeClass
         @JvmStatic


### PR DESCRIPTION
#### Description:
When signature is null return userconsent or cibaconsent. Replace deprecated fakeserver with test server


#### Testing details:
- [x]  Verified basic functionality of change
- [x]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes
- [ ] Version bump required
- [ ] Followed recommendations from the [Android Secure Coding Guidelines](https://oktawiki.atlassian.net/wiki/spaces/security/pages/2388757544/Android+Guidelines) 

##### RESOLVES: 
[OKTA-553981](https://oktainc.atlassian.net/browse/OKTA-553981)

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

