### PR TITLE
Add applicationInstallationId to appConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This library uses semantic versioning and follows Okta's [Library Version Policy
 
 | Version | Status |
 |---------|--------|
-| 1.0.0   | Stable |
+| 1.1.0   | Stable |
 
 
 The latest release can always be found on the [releases page][github-releases].
@@ -62,7 +62,7 @@ See the [Push Sample App] for a complete implementation.
 Add the Okta Devices SDK dependency to your build.gradle file:
 
 ```kotlin
-implementation("com.okta.devices:devices-push:1.0.0")
+implementation("com.okta.devices:devices-push:1.1.0")
 ```
 
 ## Usage
@@ -79,8 +79,9 @@ A complete integration requires your app to implement the following:
 Create the SDK object to work with your Okta authenticator configuration. Use the PushAuthenticatorBuilder to create an authenticator with your application configuration:
 
 ```kotlin
+val applicationInstallationId = sharedPreferences.getString(appInstallIdSharedPref, null) ?: UUID.randomUUID().toString()
 val authenticator: PushAuthenticator = PushAuthenticatorBuilder.create(
-    ApplicationConfig(context, appName = "MyApp", appVersion = BuildConfig.VERSION_NAME)
+    ApplicationConfig(context, appName = "MyApp", appVersion = BuildConfig.VERSION_NAME, applicationInstallationId)
 ) {
     passphrase = encryptedSharedPreference.getString(passphraseKey, null)?.toByteArray() // Secret must be stored securely 
 }.getOrThrow()
@@ -89,6 +90,7 @@ val authenticator: PushAuthenticator = PushAuthenticatorBuilder.create(
 If a passphrase isn't provided, then the Devices SDK data will not be encrypted. It is up to you to secure the passphrase. Please store your passphrase in a secure way: in the above example and sample
 app we use Android's [EncryptedSharedPreferences](https://developer.android.com/topic/security/data#kotlin) class.
 
+`applicationInstallationId` is used to prevent duplicate enrollments. This value must be a unique, see [Android's best practices guide guide for unique identifiers](https://developer.android.com/training/articles/user-data-ids)
 
 ### Proguard
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.0.1" apply false
-    id("com.android.library") version "8.0.1" apply false
+    id("com.android.application") version "8.0.2" apply false
+    id("com.android.library") version "8.0.2" apply false
     id("org.jetbrains.kotlin.android") version Version.kotlin apply false
-    id("org.jetbrains.dokka") version "1.7.20" apply false
+    id("org.jetbrains.dokka") version "1.8.20" apply false
     id("com.google.gms.google-services") version "4.3.15" apply false
-    id("org.jetbrains.kotlinx.kover") version "0.6.1" apply false
-    id("org.sonarqube") version "4.0.0.2929" apply true
-    id("io.gitlab.arturbosch.detekt") version "1.22.0" apply false
+    id("org.jetbrains.kotlinx.kover") version "0.7.2" apply false
+    id("org.sonarqube") version "4.2.1.3168" apply true
+    id("io.gitlab.arturbosch.detekt") version "1.23.0" apply false
 }
 
 task<Delete>("clean") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,6 +13,6 @@ repositories {
 }
 
 dependencies {
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.18.0")
-    implementation("org.owasp:dependency-check-gradle:8.2.1")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.19.0")
+    implementation("org.owasp:dependency-check-gradle:8.3.1")
 }

--- a/buildSrc/src/main/java/DevicesConfig.kt
+++ b/buildSrc/src/main/java/DevicesConfig.kt
@@ -13,7 +13,7 @@ object DevicesConfig {
     const val pushSampleAppVersionCode = 1
     const val pushSampleAppVersionName = "1.0.0"
 
-    const val devicesPushVersion = "1.0.0"
+    const val devicesPushVersion = "1.1.0"
 
     data class OssrhCredentials(
         val ossrhUsername: String,

--- a/buildSrc/src/main/java/Version.kt
+++ b/buildSrc/src/main/java/Version.kt
@@ -2,16 +2,16 @@
  * Version variables
  */
 object Version {
-    const val kotlin = "1.8.21"
-    const val kotlinSerialization = "1.5.0"
-    const val coroutine = "1.6.4"
-    const val room = "2.5.1"
+    const val kotlin = "1.8.22"
+    const val kotlinSerialization = "1.5.1"
+    const val coroutine = "1.7.1"
+    const val room = "2.5.2"
     const val extJunit = "1.1.5"
     const val archLifecycleVersion = "2.6.1"
     const val compose = "1.4.3"
-    const val composeCompiler = "1.4.7"
-    const val devicesAuthenticator = "0.0.9"
-    const val devicesCore = "0.0.9"
-    const val devicesStorage = "0.0.9"
-    const val devicesFakeServer = "0.0.9"
+    const val composeCompiler = "1.4.8"
+    const val devicesAuthenticator = "0.0.15"
+    const val devicesCore = "0.0.15"
+    const val devicesStorage = "0.0.15"
+    const val devicesFakeServer = "0.0.15"
 }

--- a/config/owasp-suppression.xml
+++ b/config/owasp-suppression.xml
@@ -4,7 +4,8 @@
         <notes><![CDATA[
    file name: kotlinx-coroutines-play-services-1.6.4.jar
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlinx/kotlinx\-coroutines\-play\-services@.*$</packageUrl>
+        <packageUrl regex="true">
+            ^pkg:maven/org\.jetbrains\.kotlinx/kotlinx\-coroutines\-play\-services@.*$</packageUrl>
         <cve>CVE-2020-22475</cve>
     </suppress>
     <suppress>
@@ -12,14 +13,24 @@
    file name:ui-1.3.0-rc01.aar
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf\-javalite@.*$</packageUrl>
+        <cve>CVE-2021-22569</cve>
         <cve>CVE-2022-3171</cve>
+        <cve>CVE-2022-3510</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
    file name: kotlinx-coroutines-play-services-1.6.4.jar
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlinx/kotlinx\-coroutines\-play\-services@.*$</packageUrl>
+        <packageUrl regex="true">
+            ^pkg:maven/org\.jetbrains\.kotlinx/kotlinx\-coroutines\-play\-services@.*$</packageUrl>
+        <cve>CVE-2022-39349</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: datastore-preferences-core-1.0.0.jar
+   ]]></notes>
+        <packageUrl regex="true">
+            ^pkg:maven/org\.jetbrains\.kotlinx/kotlinx\-coroutines\-play\-services@.*$</packageUrl>
         <cve>CVE-2022-39349</cve>
     </suppress>
 </suppressions>
-

--- a/devices-push/build.gradle.kts
+++ b/devices-push/build.gradle.kts
@@ -65,13 +65,12 @@ dependencies {
     implementation("androidx.biometric:biometric:1.2.0-alpha05")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${Version.kotlin}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Version.coroutine}")
-    implementation("androidx.core:core-ktx:1.10.0")
+    implementation("androidx.core:core-ktx:1.10.1")
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-orgjson:0.11.5") {
         exclude(group = "org.json", module = "json") // provided by Android natively
     }
-    implementation("com.google.android.gms:play-services-basement:18.2.0")
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
 
     testImplementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
@@ -82,7 +81,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Version.coroutine}")
     testImplementation("junit:junit:4.13.2")
     testImplementation("androidx.test.ext:junit-ktx:${Version.extJunit}")
-    testImplementation("org.robolectric:robolectric:4.10.1")
+    testImplementation("org.robolectric:robolectric:4.10.3")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
     testImplementation("io.mockk:mockk:1.13.5")
     testImplementation("org.hamcrest:hamcrest-library:2.2")

--- a/devices-push/src/main/java/com/okta/devices/push/PushAuthenticatorBuilder.kt
+++ b/devices-push/src/main/java/com/okta/devices/push/PushAuthenticatorBuilder.kt
@@ -15,17 +15,22 @@
 package com.okta.devices.push
 
 import android.app.Application
+import android.app.KeyguardManager
+import android.app.admin.DevicePolicyManager
 import android.content.Context
+import android.os.Build
+import android.provider.Settings
 import com.okta.devices.BuildConfig
 import com.okta.devices.DeviceAuthenticatorCore
 import com.okta.devices.api.device.DeviceInfoCollector
+import com.okta.devices.api.device.DiskEncryptionType
+import com.okta.devices.api.device.ScreenLockType
 import com.okta.devices.api.log.DeviceLog
 import com.okta.devices.api.model.ApplicationConfig
 import com.okta.devices.api.security.EncryptionProvider
 import com.okta.devices.api.security.SignatureProvider
 import com.okta.devices.api.time.DeviceClock
 import com.okta.devices.authenticator.Modules
-import com.okta.devices.device.DeviceInfoCollectorImpl
 import com.okta.devices.device.KeyInfoHint
 import com.okta.devices.device.OrgInfoHint
 import com.okta.devices.encrypt.AESEncryptionProvider
@@ -33,7 +38,7 @@ import com.okta.devices.encrypt.CryptoFactory
 import com.okta.devices.encrypt.DeviceKeyStoreImpl
 import com.okta.devices.encrypt.RsaSignature
 import com.okta.devices.http.DeviceOkHttpClient
-import com.okta.devices.http.UserAgent
+import com.okta.devices.http.UserAgentImpl
 import com.okta.devices.push.api.PushAuthenticator
 import com.okta.devices.storage.AuthenticatorDatabase
 import com.okta.devices.storage.EncryptionOption
@@ -55,7 +60,46 @@ class PushAuthenticatorBuilder internal constructor(context: Application) {
     internal var deviceStore: DeviceStore? = null
     internal var deviceClock: DeviceClock = DeviceClock { System.currentTimeMillis() }
     internal var coroutineScope: CoroutineScope = CoroutineScope(Job() + Dispatchers.IO)
-    internal var deviceInfoCollector: DeviceInfoCollector = DeviceInfoCollectorImpl(context)
+    internal var deviceInfoCollector: DeviceInfoCollector = object : DeviceInfoCollector {
+        private val keyguardManager = context.getSystemService(KeyguardManager::class.java)
+        private val devicePolicyManager = context.getSystemService(DevicePolicyManager::class.java)
+        private val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+
+        override fun appVersion(): String = packageInfo?.versionName ?: Build.UNKNOWN
+        override fun appBundleId(): String = packageInfo?.applicationInfo?.packageName ?: Build.UNKNOWN
+        override fun userDefinedDeviceName(): String {
+            // Settings.Global.device_name seems to have the most success among more recent devices.
+            return Settings.Global.getString(context.contentResolver, "device_name")
+                ?: Settings.Secure.getString(context.contentResolver, "device_name")
+                // May work better for older devices.
+                ?: Settings.System.getString(context.contentResolver, "bluetooth_name")
+                ?: Settings.Secure.getString(context.contentResolver, "bluetooth_name")
+                ?: Build.MODEL
+        }
+
+        override fun screenLockType(): ScreenLockType = when (keyguardManager?.isDeviceSecure) {
+            true -> ScreenLockType.PASSCODE
+            else -> ScreenLockType.NONE
+        }
+
+        override fun serialNumber(): String? = null
+
+        override fun udid(): String? = null
+
+        override fun diskEncryptionType(): DiskEncryptionType {
+            val diskEncryptionStatus = devicePolicyManager?.storageEncryptionStatus
+                ?: DevicePolicyManager.ENCRYPTION_STATUS_UNSUPPORTED
+            return when (diskEncryptionStatus) {
+                DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE_PER_USER -> DiskEncryptionType.USER
+                DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE,
+                DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE_DEFAULT_KEY,
+                DevicePolicyManager.ENCRYPTION_STATUS_ACTIVATING,
+                -> DiskEncryptionType.FULL
+
+                else -> DiskEncryptionType.NONE
+            }
+        }
+    }
 
     private val deviceKeyStore = lazy { DeviceKeyStoreImpl() }
     internal var signer: SignatureProvider = RsaSignature(deviceKeyStore.value)
@@ -110,7 +154,7 @@ class PushAuthenticatorBuilder internal constructor(context: Application) {
         return Modules(
             checkNotNull(deviceStore),
             cryptoFactory,
-            DeviceOkHttpClient(UserAgent(context, BuildConfig.VERSION_NAME), okHttpClient),
+            DeviceOkHttpClient(UserAgentImpl(context, BuildConfig.VERSION_NAME), okHttpClient),
             deviceClock,
             deviceLog,
             deviceInfoCollector,

--- a/devices-push/src/test/java/com/okta/devices/push/PushAuthenticatorBuilderTest.kt
+++ b/devices-push/src/test/java/com/okta/devices/push/PushAuthenticatorBuilderTest.kt
@@ -18,6 +18,7 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.okta.devices.api.model.ApplicationConfig
+import com.okta.devices.fake.util.uuid
 import com.okta.devices.push.utils.BaseTest
 import com.okta.devices.storage.AuthenticatorDatabase
 import com.okta.devices.storage.EncryptionOption
@@ -30,13 +31,13 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class PushAuthenticatorBuilderTest : BaseTest() {
     private val context = ApplicationProvider.getApplicationContext<Application>()
-
+    private val applicationInstallationId = uuid()
     private val inMemoryDataStore = AuthenticatorDatabase.instance(context, EncryptionOption.None, true)
 
     @Test
     fun `create push authenticator, expect push authenticator returned`() {
         // arrange
-        val appConfig = ApplicationConfig(context, "MyApp", "1.0.0")
+        val appConfig = ApplicationConfig(context, "MyApp", "1.0.0", applicationInstallationId)
 
         // act
         val pushAuthenticator = PushAuthenticatorBuilder.create(appConfig) {

--- a/push-sample-app/build.gradle.kts
+++ b/push-sample-app/build.gradle.kts
@@ -73,10 +73,10 @@ dependencies {
     implementation("com.okta.kotlin:oauth2")
     implementation("com.okta.kotlin:web-authentication-ui")
 
-    implementation("androidx.core:core-ktx:1.10.0")
+    implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.biometric:biometric:1.2.0-alpha05")
-    implementation("androidx.activity:activity-compose:1.7.1")
+    implementation("androidx.activity:activity-compose:1.7.2")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:${Version.archLifecycleVersion}")
     implementation("androidx.compose.material:material:${Version.compose}")
     implementation("androidx.compose.ui:ui:${Version.compose}")
@@ -84,12 +84,12 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview:${Version.compose}")
     implementation("androidx.compose.runtime:runtime:${Version.compose}")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.1")
 
     implementation("com.jakewharton.timber:timber:5.0.1")
 
     // Firebase BoM
-    implementation(platform("com.google.firebase:firebase-bom:32.0.0"))
+    implementation(platform("com.google.firebase:firebase-bom:32.1.1"))
     implementation("com.google.firebase:firebase-messaging-ktx")
     implementation("androidx.security:security-crypto-ktx:1.1.0-alpha06")
 }

--- a/push-sample-app/src/main/java/example/okta/android/sample/client/AuthenticatorClient.kt
+++ b/push-sample-app/src/main/java/example/okta/android/sample/client/AuthenticatorClient.kt
@@ -39,6 +39,7 @@ import example.okta.android.sample.errors.AuthenticatorError
 import timber.log.Timber
 import java.lang.StringBuilder
 import java.net.URL
+import java.util.UUID
 
 /**
  * PushAuthenticator use cases: enable or disable push MFA, list existing push enrollment, enable or disable biometric,
@@ -61,6 +62,7 @@ class AuthenticatorClient(app: Application, private val oidcClient: OktaOidcClie
     private val manageScope = listOf("okta.myAccount.appAuthenticator.maintenance.manage")
     private val readScope = listOf("okta.myAccount.appAuthenticator.maintenance.read")
     private val passphraseSharedPref: String = "passphraseSharedPref"
+    private val appInstallIdSharedPref: String = "appInstallIdSharedPref"
     private val sharedPreferences: SharedPreferences = EncryptedSharedPreferences.create(
         app,
         passphraseSharedPref,
@@ -73,7 +75,7 @@ class AuthenticatorClient(app: Application, private val oidcClient: OktaOidcClie
 
     // Create the PushAuthenticator and customize the DeviceLog to use timber
     private val pushAuthenticator: PushAuthenticator = PushAuthenticatorBuilder.create(
-        ApplicationConfig(app, appName = BuildConfig.APPLICATION_ID, appVersion = BuildConfig.VERSION_NAME)
+        ApplicationConfig(app, appName = BuildConfig.APPLICATION_ID, appVersion = BuildConfig.VERSION_NAME, getApplicationInstallationId())
     ) {
         // Override the default log with Timber
         deviceLog = object : DeviceLog {
@@ -153,5 +155,9 @@ class AuthenticatorClient(app: Application, private val oidcClient: OktaOidcClie
 
     private fun getPassphrase(): String {
         return sharedPreferences.getString(passphraseSharedPref, null) ?: generatePassphrase()
+    }
+
+    private fun getApplicationInstallationId(): String {
+        return sharedPreferences.getString(appInstallIdSharedPref, null) ?: UUID.randomUUID().toString()
     }
 }

--- a/push-sample-app/src/main/java/example/okta/android/sample/composable/Common.kt
+++ b/push-sample-app/src/main/java/example/okta/android/sample/composable/Common.kt
@@ -143,7 +143,7 @@ fun CommonDialog(
 ) {
     if (initialState) {
         AlertDialog(
-            modifier = Modifier,
+            modifier = modifier,
             backgroundColor = Color(Constants.CONTENT_COLOR),
             contentColor = contentColorFor(Color(Constants.CONTENT_COLOR)),
             shape = RoundedCornerShape(20.dp),


### PR DESCRIPTION
#### Description:
The installation id will be used to prevent duplicate enrollments where the user enroll twice.

#### Testing details:
- [x]  Verified basic functionality of change
- [x]  Added tests 

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes
- [ ] Version bump required
- [ ] Followed recommendations from the [Android Secure Coding Guidelines](https://oktawiki.atlassian.net/wiki/spaces/security/pages/2388757544/Android+Guidelines) 

##### RESOLVES: 
[OKTA-626630](https://oktainc.atlassian.net/browse/OKTA-626630)

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

