### PR TITLE
Update netty to 4.1.119.Final

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ allprojects {
         resolutionStrategy {
             force("commons-io:commons-io:2.18.0")
             force("com.google.protobuf:protobuf-java:3.25.5")
-            force("io.netty:netty-codec-http2:4.1.115.Final")
+            force("io.netty:netty-codec-http2:4.1.119.Final")
             force("com.squareup.okio:okio:3.9.0")
             force("org.bouncycastle:bcprov-jdk18on:1.78.1")
             force("org.json:json:20240303")


### PR DESCRIPTION
# Description
Fixes CVE-2025-24970

## Resolves
- [OKTA-881913](https://oktainc.atlassian.net/browse/OKTA-881913)

# [Risk Assessment](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2982128884/Risk+Assessment+Level+for+AMP+-+CATS+Group#Okta-Verify)

❗**🌴 Very Low / 

❗*Rationale for the Risk Assessment*
Netty is used by build script

## Testing 
- [x] Automated Tests Added (Unit / Functional / UI)
CI/CD system validates the build is working.