### PR TITLE
Replace Bacon SCA scan with CircleCI snyk-scan job (OKTA-1104306)

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -1,8 +1,0 @@
-test_suites:
-  - name: sca-scan
-    script_path: /root/okta/okta-devices-kotlin/scripts/
-    sort_order: '1'
-    timeout: '200'
-    script_name: dependency_scan
-    criteria: MERGE
-    queue_name: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   general-platform-helpers: okta/general-platform-helpers@1.9.4
   platform-helpers: okta/platform-helpers@2.0.0
+  android: circleci/android@3.1.0
   python: circleci/python@2.1.1
   aws-cli: circleci/aws-cli@5.1
 
@@ -91,6 +92,18 @@ jobs:
               --build-env "circleci" \
               --suppress_output         
 
+  snyk-scan:
+    executor:
+      name: android/android_docker
+      tag: 2025.09.1
+    steps:
+      - checkout
+      - general-platform-helpers/step-run-snyk-monitor:
+          scan-all-projects: true
+          skip-unresolved: false
+          run-on-non-main: false
+          additional-arguments: "--configuration-matching=implementation"
+
 workflows:
   build-and-test:
     jobs:
@@ -98,6 +111,13 @@ workflows:
       - devices-push-test
       - devices-push-build
       - spotlessCheck
+      - snyk-scan:
+          context:
+            - static-analysis
+          filters:
+            branches:
+              only:
+                - master
   "Malware Scanner":
     jobs:
       - reversing-labs:


### PR DESCRIPTION
#### Description:
The Bacon CI dependency_scan suite was not working. This replaces it with a CircleCI snyk-scan job using the general-platform-helpers orb's step-run-snyk-monitor, matching the pattern from okta-mobile-kotlin. The job runs only on master with the static-analysis context.

#### Testing details:
- [ ]  Verified basic functionality of change
https://app.circleci.com/pipelines/gh/okta/okta-devices-kotlin/18/workflows/23078af7-3adf-4726-8088-ab6b3bb04644/jobs/83

#### Other considerations:
- [ ] Has security implications
- [ ] Has UX changes
- [ ] Version bump required
- [ ] Followed recommendations from the [Android Secure Coding Guidelines](https://oktawiki.atlassian.net/wiki/spaces/security/pages/2388757544/Android+Guidelines) 

##### RESOLVES: 
[OKTA-1104306](https://oktainc.atlassian.net/browse/OKTA-1104306)

#### Primary Reviewer(s):
##### Additional Reviewers:
##### Security Reviewer(s) (@ okta/rex-team if necessary):
##### UX Reviewer(s) (if necessary):

